### PR TITLE
cmd/yeet: add thin `ssh` wrapper using install user (no ssh-config edits)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Host terminology: `yeet init root@<host>` uses the SSH **machine host**. `yeet r
 ```bash
 yeet init root@<host>
 yeet run <svc> ./compose.yml
+yeet ssh
 ```
 
 Note: `yeet run` for compose does not pull new images by default. To refresh images, use `yeet run --pull <svc> ./compose.yml` or `yeet docker update <svc>`.

--- a/cmd/yeet/cli.go
+++ b/cmd/yeet/cli.go
@@ -122,6 +122,12 @@ func buildHelpConfig() yargs.HelpConfig {
 		Name:        "prefs",
 		Description: "Manage the current preferences",
 	}
+	subcommands["ssh"] = yargs.SubCommandInfo{
+		Name:        "ssh",
+		Description: "Open an SSH session to the host with the install user",
+		Usage:       "[ssh-args...]",
+		Examples:    []string{"yeet ssh", "yeet --host=<host> ssh", "yeet ssh htop"},
+	}
 	subcommands["skirt"] = yargs.SubCommandInfo{
 		Name:   "skirt",
 		Hidden: true,

--- a/cmd/yeet/yeet.go
+++ b/cmd/yeet/yeet.go
@@ -79,6 +79,7 @@ func main() {
 	handlers["init"] = yeet.HandleInit
 	handlers["list-hosts"] = handleListHosts
 	handlers["prefs"] = yeet.HandlePrefs
+	handlers["ssh"] = yeet.HandleSSH
 	handlers["skirt"] = yeet.HandleSkirt
 
 	groups := buildGroupHandlers()

--- a/pkg/yeet/ssh_cmd.go
+++ b/pkg/yeet/ssh_cmd.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2025 AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package yeet
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func HandleSSH(ctx context.Context, args []string) error {
+	if len(args) > 0 && args[0] == "ssh" {
+		args = args[1:]
+	}
+	host := Host()
+	if strings.TrimSpace(host) == "" {
+		return fmt.Errorf("no host configured")
+	}
+
+	var info serverInfo
+	if err := newRPCClient(host).Call(ctx, "catch.Info", nil, &info); err != nil {
+		return err
+	}
+
+	user := strings.TrimSpace(info.InstallUser)
+	target := host
+	if user != "" {
+		target = fmt.Sprintf("%s@%s", user, host)
+	}
+
+	if _, err := exec.LookPath("ssh"); err != nil {
+		return fmt.Errorf("ssh CLI not found in PATH")
+	}
+
+	options, commandTokens := splitSSHArgs(args)
+	sshArgs := append(append([]string{}, options...), target)
+	sshArgs = append(sshArgs, commandTokens...)
+	cmd := exec.CommandContext(ctx, "ssh", sshArgs...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func splitSSHArgs(args []string) (options []string, command []string) {
+	for i := 0; i < len(args); i++ {
+		token := args[i]
+		if token == "--" {
+			return options, args[i+1:]
+		}
+		if token == "-" || !strings.HasPrefix(token, "-") {
+			return options, args[i:]
+		}
+		options = append(options, token)
+		if sshOptionNeedsArg(token) && len(token) == 2 && i+1 < len(args) {
+			options = append(options, args[i+1])
+			i++
+		}
+	}
+	return options, nil
+}
+
+func sshOptionNeedsArg(token string) bool {
+	if len(token) < 2 || token[0] != '-' || token[1] == '-' {
+		return false
+	}
+	switch token[1] {
+	case 'B', 'b', 'c', 'D', 'E', 'F', 'I', 'i', 'J', 'L', 'l', 'm', 'O', 'o', 'p', 'Q', 'R', 'S', 'W', 'w':
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
### Motivation

- Provide a simple `yeet ssh` that launches the system `ssh` client to the catch host using the install user reported by the server.
- Avoid editing the user's `~/.ssh/config` and keep `yeet ssh` as a thin passthrough that forwards flags and remote commands.
- Remove the previous attempt to force a remote `cd` into the host data directory and instead rely on forwarding the user's command as-is. 

### Description

- Add `HandleSSH` in `pkg/yeet/ssh_cmd.go` which calls `catch.Info` to obtain `InstallUser`, builds the `user@host` target, parses args with `splitSSHArgs`, and executes the system `ssh` client forwarding options and commands. 
- Delete `pkg/yeet/ssh_config.go` to stop modifying `~/.ssh/config` and simplify behavior. 
- Remove `RootDir` from `catch.ServerInfo` and the client `serverInfo` type and update `GetInfoWithInstallUser` and the `catch.Info` RPC usage to no longer return a root data directory. 
- Wire the new command into the CLI by registering the `ssh` subcommand in `cmd/yeet/cli.go`, adding the handler in `cmd/yeet/yeet.go`, and adding `yeet ssh` usage to `README.md`.

### Testing

- No automated Go tests were run (no `go test` executed in this environment). 
- Formatting and tooling checks (`gofmt` / other Go tooling) were not executed due to environment/tooling restrictions. 
- No CI or build verification was performed as part of this change. 
- Behavior is unverified at runtime and assumes `catch.Info` returns a valid `InstallUser` field.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695aec4acf8c832796fc60becaa3333a)